### PR TITLE
Distinguish on type for property values

### DIFF
--- a/vector_tile_base/engine.py
+++ b/vector_tile_base/engine.py
@@ -555,7 +555,10 @@ class Layer(object):
                     remove.append(v)
                     continue
                 self._values.append(v)
-            tags.append(self._values.index(v))
+                value_index = len(self._values) - 1
+            else:
+                value_index = self._values.index(v)
+            tags.append(value_index)
         if remove:
             data[:] = [x for x in data if x not in remove]
         return tags
@@ -603,11 +606,15 @@ class Layer(object):
                     remove.append(k)
                     continue
                 self._values.append(v)
+                value_index = len(self._values) - 1
+            else:
+                value_index = self._values.index(v)
+
             if k not in self._keys:
                 self._layer.keys.append(k)
                 self._keys.append(k)
             tags.append(self._keys.index(k))
-            tags.append(self._values.index(v))
+            tags.append(value_index)
         for k in remove:
             del props[k]
         return tags

--- a/vector_tile_base/engine.py
+++ b/vector_tile_base/engine.py
@@ -519,7 +519,7 @@ class Layer(object):
         tags = []
         remove = []
         for v in data:
-            if v not in self._values:
+            if not (v in self._values and type(self._values[self._values.index(v)]) == type(v)):
                 if isinstance(v,bool):
                     val = self._layer.values.add()
                     val.bool_value = v
@@ -567,7 +567,7 @@ class Layer(object):
             if not isinstance(k, str) and not isinstance(k, other_str):
                 remove.append(k)
                 continue
-            if v not in self._values:
+            if not (v in self._values and type(self._values[self._values.index(v)]) == type(v)):
                 if isinstance(v,bool):
                     val = self._layer.values.add()
                     val.bool_value = v


### PR DESCRIPTION
In cases where properties are added of different types that can be coerced to the same type/value, all properties now get the type of the property first encountered. For example; when adding `1` and `1.0` the properties might both be either an int or a floating point type. This is due to the `in` operator being very flexible on typing.

This PR adds some additional checks on types when serialising properties.