### PR TITLE
Close path command must have count of 1

### DIFF
--- a/vector_tile_base/engine.py
+++ b/vector_tile_base/engine.py
@@ -24,7 +24,7 @@ def command_line_to(count):
     return command_integer(2, count)
 
 def command_close_path():
-    return command_integer(7,0)
+    return command_integer(7,1)
 
 def get_command_id(command_integer):
     return command_integer & 0x7;


### PR DESCRIPTION
From the [v2.1 vector-tile spec](https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md#4333-closepath-command), it looks like the close path command must always have a count of one. I've also reviewed the the [v3.0-development](https://github.com/mapbox/vector-tile-spec/blob/v3.0-development/2.1/README.md#4333-closepath-command) and [v3.0-3d](https://github.com/mapbox/vector-tile-spec/blob/v3.0-3d/2.1/README.md#4333-closepath-command) version of the spec. It seems the latter is at least partially considered for this implementation, per the inclusion of the dimension parameter in the protocol buffer. Nonetheless, appears neither of the 3.0 versions have changed with regard to the count of the close path command.

I was finding tiles I had generated with this package had a close path count not equal to 1 when running vtvalidate on them. Investigating further, it looks like here the close path count is set to 0, rather than 1. The change I'm submitting fixes that issue and now allows my tiles to pass validation.